### PR TITLE
Add: includeFontPadding = false to remove default padding

### DIFF
--- a/src/theme/typography.tsx
+++ b/src/theme/typography.tsx
@@ -1,4 +1,4 @@
-import { Text, TextProps } from 'react-native';
+import { Text, TextProps, Platform } from 'react-native';
 
 type FontWeight = 'regular' | 'normal' | 'medium' | 'semibold' | 'bold' | 'heavy' | 'black';
 
@@ -27,6 +27,10 @@ const sfProFontFamilyMap: Record<FontWeight, string> = {
 // Legacy font family map (for Jost backward compatibility)
 const fontFamilyMap = jostFontFamilyMap;
 
+const androidFontDefaultPaddingFix = Platform.OS === 'android' ? {
+  includeFontPadding: false
+} : {};
+
 // Helper functions to get font family based on weight
 export const getJostFontFamily = (weight: FontWeight = 'regular') => jostFontFamilyMap[weight];
 export const getSFProFontFamily = (weight: FontWeight = 'regular') => sfProFontFamilyMap[weight];
@@ -41,6 +45,7 @@ export function BaseText(props: TextProps) {
       {...props}
       style={[
         { fontFamily: fontFamilyMap.regular },
+        androidFontDefaultPaddingFix,
         props.style,
       ]}
     />
@@ -54,6 +59,7 @@ export function JostText({ style, weight = 'regular', ...props }: TextProps & { 
       {...props}
       style={[
         { fontFamily: getJostFontFamily(weight) },
+        androidFontDefaultPaddingFix,
         style,
       ]}
     />
@@ -67,6 +73,7 @@ export function SFProBaseText(props: TextProps) {
       {...props}
       style={[
         { fontFamily: sfProFontFamilyMap.regular },
+        androidFontDefaultPaddingFix,
         props.style,
       ]}
     />
@@ -80,6 +87,7 @@ export function SFProText({ style, weight = 'regular', ...props }: TextProps & {
       {...props}
       style={[
         { fontFamily: getSFProFontFamily(weight) },
+        androidFontDefaultPaddingFix,
         style,
       ]}
     />


### PR DESCRIPTION
Note: I added a code block named androidFontDefaultPaddingFix that removes the default padding values of the fonts we use. When adding a new font, don't forget to add this to the style values as well.


### Before
<img width="2400" height="1080" alt="before_android" src="https://github.com/user-attachments/assets/3c0ab3ba-a2db-4723-bc07-9d8cbbfe76bb" />

### After
<img width="2400" height="1080" alt="after_android" src="https://github.com/user-attachments/assets/6fcff585-1639-463e-9fee-17c2038344c4" />
