### PR TITLE
Add: horizontalPadding only for android tablet landscape mode

### DIFF
--- a/src/utils/gameLayout.ts
+++ b/src/utils/gameLayout.ts
@@ -1,5 +1,5 @@
 import { isLandscape, isTablet } from './device';
-
+import { Platform } from 'react-native';
 export type Rect = { left: number; top: number; width: number; height: number };
 export type LayoutResult = {
   match: Rect;
@@ -45,6 +45,9 @@ export function computeLayout(
   isPad: boolean,
   isPortrait: boolean
 ): LayoutResult {
+  const horizontalPadding = Platform.OS === 'android' && isPad && !isPortrait ? 100 : 0;
+  playW = playW - horizontalPadding;
+  playH = playH;
   const magnification = isPad ? Math.max(playW, playH) / 1024 : Math.min(playW, playH) / 320;
 
   let marginTop = 0, marginLeft = 0;


### PR DESCRIPTION
It was only an issue I encountered on Android tablets in landscape mode. I also tested it on the Samsung Tab A7 (Android 12), Google Pixel Tablet (Android 15), and iPad (OS 18.6).

### Before
<img width="2560" height="1600" alt="before_android" src="https://github.com/user-attachments/assets/f344e8e1-f479-41ee-bbd2-7ba5c729b02b" />


### After
<img width="2560" height="1600" alt="after_android" src="https://github.com/user-attachments/assets/3ad36948-5f67-4d83-badb-062aa839ef8e" />
